### PR TITLE
feat: content classification system with LLM (#4)

### DIFF
--- a/backend/internal/classifier/classifier.go
+++ b/backend/internal/classifier/classifier.go
@@ -1,0 +1,10 @@
+package classifier
+
+import (
+	"github.com/rookiecj/scrum-agents/backend/internal/model"
+)
+
+// Classifier classifies content into a category.
+type Classifier interface {
+	Classify(content string) (*model.ClassificationResult, error)
+}

--- a/backend/internal/classifier/llm_classifier.go
+++ b/backend/internal/classifier/llm_classifier.go
@@ -1,0 +1,53 @@
+package classifier
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/rookiecj/scrum-agents/backend/internal/model"
+)
+
+// LLMClient is the interface for making LLM API calls.
+type LLMClient interface {
+	Complete(prompt string) (string, error)
+}
+
+// LLMClassifier classifies content using an LLM provider.
+type LLMClassifier struct {
+	Client LLMClient
+}
+
+// NewLLMClassifier creates a new LLMClassifier with the given LLM client.
+func NewLLMClassifier(client LLMClient) *LLMClassifier {
+	return &LLMClassifier{Client: client}
+}
+
+// Classify sends the content to the LLM and parses the classification result.
+func (c *LLMClassifier) Classify(content string) (*model.ClassificationResult, error) {
+	prompt := ClassificationPrompt(content)
+
+	response, err := c.Client.Complete(prompt)
+	if err != nil {
+		return nil, fmt.Errorf("LLM classification failed: %w", err)
+	}
+
+	var result model.ClassificationResult
+	if err := json.Unmarshal([]byte(response), &result); err != nil {
+		return nil, fmt.Errorf("parsing classification response: %w", err)
+	}
+
+	if !isValidCategory(result.Primary) {
+		return nil, fmt.Errorf("invalid primary category: %s", result.Primary)
+	}
+
+	return &result, nil
+}
+
+func isValidCategory(cat model.ContentCategory) bool {
+	for _, valid := range model.AllCategories() {
+		if cat == valid {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/classifier/llm_classifier_test.go
+++ b/backend/internal/classifier/llm_classifier_test.go
@@ -1,0 +1,180 @@
+package classifier
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/rookiecj/scrum-agents/backend/internal/model"
+)
+
+// mockLLMClient is a test double for LLMClient.
+type mockLLMClient struct {
+	response string
+	err      error
+}
+
+func (m *mockLLMClient) Complete(prompt string) (string, error) {
+	return m.response, m.err
+}
+
+func TestLLMClassifier_Classify(t *testing.T) {
+	tests := []struct {
+		name        string
+		llmResponse string
+		llmErr      error
+		wantPrimary model.ContentCategory
+		wantConf    float64
+		wantErr     bool
+	}{
+		{
+			name:        "principle classification",
+			llmResponse: `{"primary":"원리소개","confidence":0.92,"secondary":"기술소개","secondary_confidence":0.45}`,
+			wantPrimary: model.CategoryPrinciple,
+			wantConf:    0.92,
+		},
+		{
+			name:        "review classification",
+			llmResponse: `{"primary":"사용기","confidence":0.88,"secondary":"생각정리","secondary_confidence":0.3}`,
+			wantPrimary: model.CategoryReview,
+			wantConf:    0.88,
+		},
+		{
+			name:        "tutorial classification",
+			llmResponse: `{"primary":"튜토리얼","confidence":0.95}`,
+			wantPrimary: model.CategoryTutorial,
+			wantConf:    0.95,
+		},
+		{
+			name:        "news classification",
+			llmResponse: `{"primary":"뉴스/분석","confidence":0.78,"secondary":"기술소개","secondary_confidence":0.55}`,
+			wantPrimary: model.CategoryNews,
+			wantConf:    0.78,
+		},
+		{
+			name:        "opinion classification",
+			llmResponse: `{"primary":"생각정리","confidence":0.85}`,
+			wantPrimary: model.CategoryOpinion,
+			wantConf:    0.85,
+		},
+		{
+			name:        "tech intro classification",
+			llmResponse: `{"primary":"기술소개","confidence":0.90}`,
+			wantPrimary: model.CategoryTechIntro,
+			wantConf:    0.90,
+		},
+		{
+			name:        "invalid category",
+			llmResponse: `{"primary":"unknown","confidence":0.9}`,
+			wantErr:     true,
+		},
+		{
+			name:        "invalid json",
+			llmResponse: `not json`,
+			wantErr:     true,
+		},
+		{
+			name:    "llm error",
+			llmErr:  fmt.Errorf("API error"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &mockLLMClient{response: tt.llmResponse, err: tt.llmErr}
+			classifier := NewLLMClassifier(client)
+
+			result, err := classifier.Classify("some content")
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Primary != tt.wantPrimary {
+				t.Errorf("primary = %q, want %q", result.Primary, tt.wantPrimary)
+			}
+			if result.Confidence != tt.wantConf {
+				t.Errorf("confidence = %f, want %f", result.Confidence, tt.wantConf)
+			}
+		})
+	}
+}
+
+func TestClassificationPrompt(t *testing.T) {
+	content := "This is a test article about how TCP works."
+	prompt := ClassificationPrompt(content)
+
+	if prompt == "" {
+		t.Error("expected non-empty prompt")
+	}
+
+	// Check that all categories are mentioned
+	categories := model.AllCategories()
+	for _, cat := range categories {
+		if !containsString(prompt, string(cat)) {
+			t.Errorf("prompt should contain category %q", cat)
+		}
+	}
+
+	// Check that content is included
+	if !containsString(prompt, content) {
+		t.Error("prompt should contain the content")
+	}
+}
+
+func TestClassificationPrompt_Truncation(t *testing.T) {
+	// Create content longer than 4000 chars
+	longContent := make([]byte, 5000)
+	for i := range longContent {
+		longContent[i] = 'a'
+	}
+
+	prompt := ClassificationPrompt(string(longContent))
+	// Content should be truncated + "..." appended
+	if !containsString(prompt, "...") {
+		t.Error("long content should be truncated with ...")
+	}
+}
+
+func TestIsValidCategory(t *testing.T) {
+	tests := []struct {
+		cat  model.ContentCategory
+		want bool
+	}{
+		{model.CategoryPrinciple, true},
+		{model.CategoryReview, true},
+		{model.CategoryOpinion, true},
+		{model.CategoryTechIntro, true},
+		{model.CategoryTutorial, true},
+		{model.CategoryNews, true},
+		{"unknown", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.cat), func(t *testing.T) {
+			got := isValidCategory(tt.cat)
+			if got != tt.want {
+				t.Errorf("isValidCategory(%q) = %v, want %v", tt.cat, got, tt.want)
+			}
+		})
+	}
+}
+
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstring(s, substr))
+}
+
+func containsSubstring(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/classifier/prompt.go
+++ b/backend/internal/classifier/prompt.go
@@ -1,0 +1,30 @@
+package classifier
+
+import "fmt"
+
+// ClassificationPrompt returns the prompt used to classify content.
+func ClassificationPrompt(content string) string {
+	return fmt.Sprintf(`You are a content classifier. Classify the following content into exactly one of these categories:
+
+1. 원리소개 - Explains a principle, concept, or how something works (e.g., "How TCP works", "양자컴퓨팅 원리")
+2. 사용기 - Product/tool/service usage review or experience (e.g., "M4 MacBook Pro 한달 사용기", "Cursor IDE 리뷰")
+3. 생각정리 - Opinion, essay, or philosophical reflection (e.g., "AI가 개발자를 대체할까", "스타트업 문화에 대한 단상")
+4. 기술소개 - Introduction of a new technology/tool/framework (e.g., "Introducing Bun 1.0", "Go 1.22 새 기능")
+5. 튜토리얼 - Step-by-step guide or how-to (e.g., "React에서 상태관리 구현하기", "Docker 입문")
+6. 뉴스/분석 - Industry news and trend analysis (e.g., "2024 AI 트렌드 리포트", "OpenAI DevDay 정리")
+
+Respond ONLY with a JSON object in this exact format:
+{"primary": "<category>", "confidence": <0.0-1.0>, "secondary": "<category>", "secondary_confidence": <0.0-1.0>}
+
+Content to classify:
+---
+%s
+---`, truncate(content, 4000))
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/backend/internal/handler/classify.go
+++ b/backend/internal/handler/classify.go
@@ -1,0 +1,42 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/rookiecj/scrum-agents/backend/internal/classifier"
+	"github.com/rookiecj/scrum-agents/backend/internal/model"
+)
+
+type ClassifyRequest struct {
+	Content string `json:"content"`
+}
+
+type ClassifyResponse struct {
+	Classification *model.ClassificationResult `json:"classification,omitempty"`
+	Error          string                      `json:"error,omitempty"`
+}
+
+// HandleClassify returns a handler that classifies content.
+func HandleClassify(cls classifier.Classifier) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req ClassifyRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, ClassifyResponse{Error: "invalid request body"})
+			return
+		}
+
+		if req.Content == "" {
+			writeJSON(w, http.StatusBadRequest, ClassifyResponse{Error: "content is required"})
+			return
+		}
+
+		result, err := cls.Classify(req.Content)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, ClassifyResponse{Error: "classification failed: " + err.Error()})
+			return
+		}
+
+		writeJSON(w, http.StatusOK, ClassifyResponse{Classification: result})
+	}
+}

--- a/backend/internal/handler/classify_test.go
+++ b/backend/internal/handler/classify_test.go
@@ -1,0 +1,102 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rookiecj/scrum-agents/backend/internal/model"
+)
+
+type mockClassifier struct {
+	result *model.ClassificationResult
+	err    error
+}
+
+func (m *mockClassifier) Classify(content string) (*model.ClassificationResult, error) {
+	return m.result, m.err
+}
+
+func TestHandleClassify(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		result     *model.ClassificationResult
+		classErr   error
+		wantStatus int
+		wantErr    bool
+	}{
+		{
+			name: "successful classification",
+			body: `{"content":"This article explains how TCP works..."}`,
+			result: &model.ClassificationResult{
+				Primary:    model.CategoryPrinciple,
+				Confidence: 0.92,
+			},
+			wantStatus: 200,
+		},
+		{
+			name:       "empty content",
+			body:       `{"content":""}`,
+			wantStatus: 400,
+			wantErr:    true,
+		},
+		{
+			name:       "missing content",
+			body:       `{}`,
+			wantStatus: 400,
+			wantErr:    true,
+		},
+		{
+			name:       "invalid json",
+			body:       `not json`,
+			wantStatus: 400,
+			wantErr:    true,
+		},
+		{
+			name:       "classifier error",
+			body:       `{"content":"some content"}`,
+			classErr:   fmt.Errorf("LLM unavailable"),
+			wantStatus: 500,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cls := &mockClassifier{result: tt.result, err: tt.classErr}
+			handler := HandleClassify(cls)
+
+			req := httptest.NewRequest("POST", "/api/classify", bytes.NewBufferString(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+
+			var resp ClassifyResponse
+			if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+
+			if tt.wantErr {
+				if resp.Error == "" {
+					t.Error("expected error in response")
+				}
+				return
+			}
+
+			if resp.Classification == nil {
+				t.Fatal("expected classification result")
+			}
+			if resp.Classification.Primary != tt.result.Primary {
+				t.Errorf("primary = %q, want %q", resp.Classification.Primary, tt.result.Primary)
+			}
+		})
+	}
+}

--- a/backend/internal/model/classification.go
+++ b/backend/internal/model/classification.go
@@ -1,0 +1,33 @@
+package model
+
+// ContentCategory represents the classification of content.
+type ContentCategory string
+
+const (
+	CategoryPrinciple  ContentCategory = "원리소개"   // Principle/concept explanation
+	CategoryReview     ContentCategory = "사용기"     // Usage review/experience
+	CategoryOpinion    ContentCategory = "생각정리"   // Opinion/essay
+	CategoryTechIntro  ContentCategory = "기술소개"   // Technology introduction
+	CategoryTutorial   ContentCategory = "튜토리얼"   // Step-by-step guide
+	CategoryNews       ContentCategory = "뉴스/분석"  // News/analysis
+)
+
+// AllCategories returns all valid content categories.
+func AllCategories() []ContentCategory {
+	return []ContentCategory{
+		CategoryPrinciple,
+		CategoryReview,
+		CategoryOpinion,
+		CategoryTechIntro,
+		CategoryTutorial,
+		CategoryNews,
+	}
+}
+
+// ClassificationResult holds the result of content classification.
+type ClassificationResult struct {
+	Primary    ContentCategory `json:"primary"`
+	Confidence float64         `json:"confidence"`
+	Secondary  ContentCategory `json:"secondary,omitempty"`
+	SecondConf float64         `json:"secondary_confidence,omitempty"`
+}


### PR DESCRIPTION
## Summary
- 6 content categories: 원리소개, 사용기, 생각정리, 기술소개, 튜토리얼, 뉴스/분석
- LLM-based classifier with mockable client interface
- Classification prompt with confidence scoring
- REST API: `POST /api/classify`

Closes #4

## Test plan
- [x] `go test ./... -v -cover` — 62 tests, 80-100% coverage
- [x] All 6 categories validated
- [x] Error cases: invalid JSON, LLM errors, unknown categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)