### PR TITLE
feat: multi-LLM adapter for Claude and OpenAI (#6)

### DIFF
--- a/backend/internal/llm/adapter.go
+++ b/backend/internal/llm/adapter.go
@@ -1,0 +1,89 @@
+package llm
+
+import (
+	"fmt"
+
+	"github.com/rookiecj/scrum-agents/backend/internal/model"
+)
+
+// Adapter manages multiple LLM providers and routes requests to the selected one.
+type Adapter struct {
+	providers      map[ProviderType]Provider
+	defaultProvider ProviderType
+}
+
+// NewAdapter creates an Adapter with the given providers and default.
+func NewAdapter(defaultProvider ProviderType, providers ...Provider) (*Adapter, error) {
+	if len(providers) == 0 {
+		return nil, fmt.Errorf("at least one provider is required")
+	}
+
+	a := &Adapter{
+		providers:      make(map[ProviderType]Provider),
+		defaultProvider: defaultProvider,
+	}
+
+	for _, p := range providers {
+		a.providers[p.Name()] = p
+	}
+
+	if _, ok := a.providers[defaultProvider]; !ok {
+		return nil, fmt.Errorf("default provider %q not found in registered providers", defaultProvider)
+	}
+
+	return a, nil
+}
+
+// GetProvider returns the provider for the given type, or the default if empty.
+func (a *Adapter) GetProvider(providerType ProviderType) (Provider, error) {
+	if providerType == "" {
+		providerType = a.defaultProvider
+	}
+
+	p, ok := a.providers[providerType]
+	if !ok {
+		return nil, fmt.Errorf("provider %q not available", providerType)
+	}
+	return p, nil
+}
+
+// Complete sends a prompt using the specified or default provider.
+func (a *Adapter) Complete(prompt string, providerType ProviderType) (string, error) {
+	p, err := a.GetProvider(providerType)
+	if err != nil {
+		return "", err
+	}
+	return p.Complete(prompt)
+}
+
+// Classify classifies content using the specified or default provider.
+func (a *Adapter) Classify(content string, providerType ProviderType) (*model.ClassificationResult, error) {
+	p, err := a.GetProvider(providerType)
+	if err != nil {
+		return nil, err
+	}
+	return p.Classify(content)
+}
+
+// Summarize generates a summary using the specified or default provider.
+func (a *Adapter) Summarize(content string, category model.ContentCategory, providerType ProviderType) (string, error) {
+	p, err := a.GetProvider(providerType)
+	if err != nil {
+		return "", err
+	}
+	return p.Summarize(content, category)
+}
+
+// AvailableProviders returns the list of registered provider types.
+func (a *Adapter) AvailableProviders() []ProviderType {
+	var types []ProviderType
+	for t := range a.providers {
+		types = append(types, t)
+	}
+	return types
+}
+
+// DefaultProvider returns the default provider type.
+func (a *Adapter) DefaultProvider() ProviderType {
+	return a.defaultProvider
+}

--- a/backend/internal/llm/adapter_test.go
+++ b/backend/internal/llm/adapter_test.go
@@ -1,0 +1,235 @@
+package llm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/rookiecj/scrum-agents/backend/internal/model"
+)
+
+// mockProvider is a test double for Provider.
+type mockProvider struct {
+	name        ProviderType
+	completeRes string
+	completeErr error
+	classifyRes *model.ClassificationResult
+	classifyErr error
+	summarizeRes string
+	summarizeErr error
+}
+
+func (m *mockProvider) Complete(prompt string) (string, error) {
+	return m.completeRes, m.completeErr
+}
+
+func (m *mockProvider) Classify(content string) (*model.ClassificationResult, error) {
+	return m.classifyRes, m.classifyErr
+}
+
+func (m *mockProvider) Summarize(content string, category model.ContentCategory) (string, error) {
+	return m.summarizeRes, m.summarizeErr
+}
+
+func (m *mockProvider) Name() ProviderType {
+	return m.name
+}
+
+func TestNewAdapter(t *testing.T) {
+	tests := []struct {
+		name           string
+		defaultProvider ProviderType
+		providers      []Provider
+		wantErr        bool
+	}{
+		{
+			name:           "single provider",
+			defaultProvider: ProviderClaude,
+			providers:      []Provider{&mockProvider{name: ProviderClaude}},
+		},
+		{
+			name:           "multiple providers",
+			defaultProvider: ProviderClaude,
+			providers: []Provider{
+				&mockProvider{name: ProviderClaude},
+				&mockProvider{name: ProviderOpenAI},
+			},
+		},
+		{
+			name:           "no providers",
+			defaultProvider: ProviderClaude,
+			providers:      []Provider{},
+			wantErr:        true,
+		},
+		{
+			name:           "default not found",
+			defaultProvider: ProviderClaude,
+			providers:      []Provider{&mockProvider{name: ProviderOpenAI}},
+			wantErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a, err := NewAdapter(tt.defaultProvider, tt.providers...)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if a == nil {
+				t.Fatal("expected non-nil adapter")
+			}
+		})
+	}
+}
+
+func TestAdapter_GetProvider(t *testing.T) {
+	claude := &mockProvider{name: ProviderClaude}
+	openai := &mockProvider{name: ProviderOpenAI}
+	adapter, _ := NewAdapter(ProviderClaude, claude, openai)
+
+	tests := []struct {
+		name     string
+		provider ProviderType
+		want     ProviderType
+		wantErr  bool
+	}{
+		{name: "get claude", provider: ProviderClaude, want: ProviderClaude},
+		{name: "get openai", provider: ProviderOpenAI, want: ProviderOpenAI},
+		{name: "get default (empty)", provider: "", want: ProviderClaude},
+		{name: "unknown provider", provider: "unknown", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := adapter.GetProvider(tt.provider)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if p.Name() != tt.want {
+				t.Errorf("provider = %q, want %q", p.Name(), tt.want)
+			}
+		})
+	}
+}
+
+func TestAdapter_Complete(t *testing.T) {
+	claude := &mockProvider{name: ProviderClaude, completeRes: "claude response"}
+	openai := &mockProvider{name: ProviderOpenAI, completeRes: "openai response"}
+	adapter, _ := NewAdapter(ProviderClaude, claude, openai)
+
+	tests := []struct {
+		name     string
+		provider ProviderType
+		want     string
+		wantErr  bool
+	}{
+		{name: "claude", provider: ProviderClaude, want: "claude response"},
+		{name: "openai", provider: ProviderOpenAI, want: "openai response"},
+		{name: "default", provider: "", want: "claude response"},
+		{name: "unknown", provider: "unknown", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := adapter.Complete("prompt", tt.provider)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Complete() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAdapter_Classify(t *testing.T) {
+	result := &model.ClassificationResult{
+		Primary:    model.CategoryTutorial,
+		Confidence: 0.95,
+	}
+	claude := &mockProvider{name: ProviderClaude, classifyRes: result}
+	adapter, _ := NewAdapter(ProviderClaude, claude)
+
+	got, err := adapter.Classify("content", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Primary != model.CategoryTutorial {
+		t.Errorf("primary = %q, want %q", got.Primary, model.CategoryTutorial)
+	}
+}
+
+func TestAdapter_Summarize(t *testing.T) {
+	claude := &mockProvider{name: ProviderClaude, summarizeRes: "summary text"}
+	adapter, _ := NewAdapter(ProviderClaude, claude)
+
+	got, err := adapter.Summarize("content", model.CategoryPrinciple, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "summary text" {
+		t.Errorf("Summarize() = %q, want %q", got, "summary text")
+	}
+}
+
+func TestAdapter_ErrorPropagation(t *testing.T) {
+	claude := &mockProvider{
+		name:        ProviderClaude,
+		completeErr: fmt.Errorf("API down"),
+		classifyErr: fmt.Errorf("classify error"),
+		summarizeErr: fmt.Errorf("summarize error"),
+	}
+	adapter, _ := NewAdapter(ProviderClaude, claude)
+
+	_, err := adapter.Complete("prompt", "")
+	if err == nil {
+		t.Error("expected error from Complete")
+	}
+
+	_, err = adapter.Classify("content", "")
+	if err == nil {
+		t.Error("expected error from Classify")
+	}
+
+	_, err = adapter.Summarize("content", model.CategoryNews, "")
+	if err == nil {
+		t.Error("expected error from Summarize")
+	}
+}
+
+func TestAdapter_AvailableProviders(t *testing.T) {
+	claude := &mockProvider{name: ProviderClaude}
+	openai := &mockProvider{name: ProviderOpenAI}
+	adapter, _ := NewAdapter(ProviderClaude, claude, openai)
+
+	providers := adapter.AvailableProviders()
+	if len(providers) != 2 {
+		t.Errorf("got %d providers, want 2", len(providers))
+	}
+}
+
+func TestAdapter_DefaultProvider(t *testing.T) {
+	claude := &mockProvider{name: ProviderClaude}
+	adapter, _ := NewAdapter(ProviderClaude, claude)
+
+	if adapter.DefaultProvider() != ProviderClaude {
+		t.Errorf("default = %q, want %q", adapter.DefaultProvider(), ProviderClaude)
+	}
+}

--- a/backend/internal/llm/claude.go
+++ b/backend/internal/llm/claude.go
@@ -1,0 +1,117 @@
+package llm
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/rookiecj/scrum-agents/backend/internal/classifier"
+	"github.com/rookiecj/scrum-agents/backend/internal/model"
+)
+
+// ClaudeProvider implements the Provider interface for Anthropic's Claude API.
+type ClaudeProvider struct {
+	config     Config
+	client     *http.Client
+	baseURL    string
+	classifier *classifier.LLMClassifier
+}
+
+// NewClaudeProvider creates a new Claude provider.
+func NewClaudeProvider(config Config) *ClaudeProvider {
+	p := &ClaudeProvider{
+		config:  config,
+		client:  &http.Client{Timeout: config.Timeout},
+		baseURL: "https://api.anthropic.com/v1",
+	}
+	p.classifier = classifier.NewLLMClassifier(p)
+	return p
+}
+
+// Name returns the provider type.
+func (p *ClaudeProvider) Name() ProviderType {
+	return ProviderClaude
+}
+
+type claudeRequest struct {
+	Model     string           `json:"model"`
+	MaxTokens int              `json:"max_tokens"`
+	Messages  []claudeMessage  `json:"messages"`
+}
+
+type claudeMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type claudeResponse struct {
+	Content []struct {
+		Text string `json:"text"`
+	} `json:"content"`
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+// Complete sends a prompt to Claude and returns the response.
+func (p *ClaudeProvider) Complete(prompt string) (string, error) {
+	reqBody := claudeRequest{
+		Model:     p.config.Model,
+		MaxTokens: p.config.MaxTokens,
+		Messages: []claudeMessage{
+			{Role: "user", Content: prompt},
+		},
+	}
+
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("marshaling request: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", p.baseURL+"/messages", bytes.NewReader(jsonBody))
+	if err != nil {
+		return "", fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", p.config.APIKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("calling Claude API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading response: %w", err)
+	}
+
+	var result claudeResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("parsing response: %w", err)
+	}
+
+	if result.Error != nil {
+		return "", fmt.Errorf("Claude API error: %s", result.Error.Message)
+	}
+
+	if len(result.Content) == 0 {
+		return "", fmt.Errorf("empty response from Claude")
+	}
+
+	return result.Content[0].Text, nil
+}
+
+// Classify classifies content using Claude.
+func (p *ClaudeProvider) Classify(content string) (*model.ClassificationResult, error) {
+	return p.classifier.Classify(content)
+}
+
+// Summarize generates a summary using Claude.
+func (p *ClaudeProvider) Summarize(content string, category model.ContentCategory) (string, error) {
+	prompt := fmt.Sprintf("Summarize the following %s content concisely:\n\n%s", string(category), content)
+	return p.Complete(prompt)
+}

--- a/backend/internal/llm/claude_test.go
+++ b/backend/internal/llm/claude_test.go
@@ -1,0 +1,99 @@
+package llm
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestClaudeProvider_Complete(t *testing.T) {
+	tests := []struct {
+		name       string
+		response   claudeResponse
+		statusCode int
+		want       string
+		wantErr    bool
+	}{
+		{
+			name: "successful response",
+			response: claudeResponse{
+				Content: []struct {
+					Text string `json:"text"`
+				}{{Text: "Hello from Claude"}},
+			},
+			statusCode: 200,
+			want:       "Hello from Claude",
+		},
+		{
+			name: "api error",
+			response: claudeResponse{
+				Error: &struct {
+					Message string `json:"message"`
+				}{Message: "invalid API key"},
+			},
+			statusCode: 401,
+			wantErr:    true,
+		},
+		{
+			name: "empty response",
+			response: claudeResponse{
+				Content: []struct {
+					Text string `json:"text"`
+				}{},
+			},
+			statusCode: 200,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Verify headers
+				if r.Header.Get("x-api-key") != "test-key" {
+					t.Error("missing x-api-key header")
+				}
+				if r.Header.Get("anthropic-version") != "2023-06-01" {
+					t.Error("missing anthropic-version header")
+				}
+
+				w.WriteHeader(tt.statusCode)
+				json.NewEncoder(w).Encode(tt.response)
+			}))
+			defer server.Close()
+
+			p := &ClaudeProvider{
+				config:  Config{APIKey: "test-key", Model: "claude-sonnet-4-6", MaxTokens: 1024},
+				client:  server.Client(),
+				baseURL: server.URL,
+			}
+
+			got, err := p.Complete("test prompt")
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Complete() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClaudeProvider_Name(t *testing.T) {
+	p := NewClaudeProvider(Config{APIKey: "test", Timeout: 5 * time.Second})
+	if p.Name() != ProviderClaude {
+		t.Errorf("Name() = %q, want %q", p.Name(), ProviderClaude)
+	}
+}
+
+func TestClaudeProvider_ImplementsProvider(t *testing.T) {
+	var _ Provider = &ClaudeProvider{}
+}

--- a/backend/internal/llm/config.go
+++ b/backend/internal/llm/config.go
@@ -1,0 +1,34 @@
+package llm
+
+import "time"
+
+// Config holds configuration for an LLM provider.
+type Config struct {
+	APIKey     string        `json:"api_key"`
+	Model      string        `json:"model"`
+	MaxTokens  int           `json:"max_tokens"`
+	Timeout    time.Duration `json:"timeout"`
+	MaxRetries int           `json:"max_retries"`
+}
+
+// DefaultClaudeConfig returns default configuration for Claude.
+func DefaultClaudeConfig(apiKey string) Config {
+	return Config{
+		APIKey:     apiKey,
+		Model:      "claude-sonnet-4-6",
+		MaxTokens:  4096,
+		Timeout:    30 * time.Second,
+		MaxRetries: 3,
+	}
+}
+
+// DefaultOpenAIConfig returns default configuration for OpenAI.
+func DefaultOpenAIConfig(apiKey string) Config {
+	return Config{
+		APIKey:     apiKey,
+		Model:      "gpt-4o",
+		MaxTokens:  4096,
+		Timeout:    30 * time.Second,
+		MaxRetries: 3,
+	}
+}

--- a/backend/internal/llm/openai.go
+++ b/backend/internal/llm/openai.go
@@ -1,0 +1,118 @@
+package llm
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/rookiecj/scrum-agents/backend/internal/classifier"
+	"github.com/rookiecj/scrum-agents/backend/internal/model"
+)
+
+// OpenAIProvider implements the Provider interface for OpenAI's API.
+type OpenAIProvider struct {
+	config     Config
+	client     *http.Client
+	baseURL    string
+	classifier *classifier.LLMClassifier
+}
+
+// NewOpenAIProvider creates a new OpenAI provider.
+func NewOpenAIProvider(config Config) *OpenAIProvider {
+	p := &OpenAIProvider{
+		config:  config,
+		client:  &http.Client{Timeout: config.Timeout},
+		baseURL: "https://api.openai.com/v1",
+	}
+	p.classifier = classifier.NewLLMClassifier(p)
+	return p
+}
+
+// Name returns the provider type.
+func (p *OpenAIProvider) Name() ProviderType {
+	return ProviderOpenAI
+}
+
+type openaiRequest struct {
+	Model     string          `json:"model"`
+	Messages  []openaiMessage `json:"messages"`
+	MaxTokens int             `json:"max_tokens"`
+}
+
+type openaiMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type openaiResponse struct {
+	Choices []struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+// Complete sends a prompt to OpenAI and returns the response.
+func (p *OpenAIProvider) Complete(prompt string) (string, error) {
+	reqBody := openaiRequest{
+		Model: p.config.Model,
+		Messages: []openaiMessage{
+			{Role: "user", Content: prompt},
+		},
+		MaxTokens: p.config.MaxTokens,
+	}
+
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("marshaling request: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", p.baseURL+"/chat/completions", bytes.NewReader(jsonBody))
+	if err != nil {
+		return "", fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+p.config.APIKey)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("calling OpenAI API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading response: %w", err)
+	}
+
+	var result openaiResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("parsing response: %w", err)
+	}
+
+	if result.Error != nil {
+		return "", fmt.Errorf("OpenAI API error: %s", result.Error.Message)
+	}
+
+	if len(result.Choices) == 0 {
+		return "", fmt.Errorf("empty response from OpenAI")
+	}
+
+	return result.Choices[0].Message.Content, nil
+}
+
+// Classify classifies content using OpenAI.
+func (p *OpenAIProvider) Classify(content string) (*model.ClassificationResult, error) {
+	return p.classifier.Classify(content)
+}
+
+// Summarize generates a summary using OpenAI.
+func (p *OpenAIProvider) Summarize(content string, category model.ContentCategory) (string, error) {
+	prompt := fmt.Sprintf("Summarize the following %s content concisely:\n\n%s", string(category), content)
+	return p.Complete(prompt)
+}

--- a/backend/internal/llm/openai_test.go
+++ b/backend/internal/llm/openai_test.go
@@ -1,0 +1,102 @@
+package llm
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestOpenAIProvider_Complete(t *testing.T) {
+	tests := []struct {
+		name       string
+		response   openaiResponse
+		statusCode int
+		want       string
+		wantErr    bool
+	}{
+		{
+			name: "successful response",
+			response: openaiResponse{
+				Choices: []struct {
+					Message struct {
+						Content string `json:"content"`
+					} `json:"message"`
+				}{{Message: struct {
+					Content string `json:"content"`
+				}{Content: "Hello from OpenAI"}}},
+			},
+			statusCode: 200,
+			want:       "Hello from OpenAI",
+		},
+		{
+			name: "api error",
+			response: openaiResponse{
+				Error: &struct {
+					Message string `json:"message"`
+				}{Message: "rate limit exceeded"},
+			},
+			statusCode: 429,
+			wantErr:    true,
+		},
+		{
+			name: "empty choices",
+			response: openaiResponse{
+				Choices: []struct {
+					Message struct {
+						Content string `json:"content"`
+					} `json:"message"`
+				}{},
+			},
+			statusCode: 200,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Verify auth header
+				if r.Header.Get("Authorization") != "Bearer test-key" {
+					t.Error("missing Authorization header")
+				}
+
+				w.WriteHeader(tt.statusCode)
+				json.NewEncoder(w).Encode(tt.response)
+			}))
+			defer server.Close()
+
+			p := &OpenAIProvider{
+				config:  Config{APIKey: "test-key", Model: "gpt-4o", MaxTokens: 1024},
+				client:  server.Client(),
+				baseURL: server.URL,
+			}
+
+			got, err := p.Complete("test prompt")
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Complete() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOpenAIProvider_Name(t *testing.T) {
+	p := NewOpenAIProvider(Config{APIKey: "test", Timeout: 5 * time.Second})
+	if p.Name() != ProviderOpenAI {
+		t.Errorf("Name() = %q, want %q", p.Name(), ProviderOpenAI)
+	}
+}
+
+func TestOpenAIProvider_ImplementsProvider(t *testing.T) {
+	var _ Provider = &OpenAIProvider{}
+}

--- a/backend/internal/llm/provider.go
+++ b/backend/internal/llm/provider.go
@@ -1,0 +1,28 @@
+package llm
+
+import (
+	"github.com/rookiecj/scrum-agents/backend/internal/model"
+)
+
+// ProviderType identifies an LLM provider.
+type ProviderType string
+
+const (
+	ProviderClaude ProviderType = "claude"
+	ProviderOpenAI ProviderType = "openai"
+)
+
+// Provider defines the interface for LLM providers.
+type Provider interface {
+	// Complete sends a prompt and returns the response text.
+	Complete(prompt string) (string, error)
+
+	// Classify classifies content into a category.
+	Classify(content string) (*model.ClassificationResult, error)
+
+	// Summarize generates a summary of the content.
+	Summarize(content string, category model.ContentCategory) (string, error)
+
+	// Name returns the provider name.
+	Name() ProviderType
+}


### PR DESCRIPTION
## Summary
- Provider interface: Complete, Classify, Summarize
- Claude provider (Anthropic Messages API)
- OpenAI provider (Chat Completions API)
- Adapter pattern with default provider routing
- Config with sensible defaults for both providers

Closes #6

## Test plan
- [x] `go test ./... -v -cover` — 91 tests, 78-100% coverage
- [x] Both providers tested with httptest
- [x] Adapter routing: specific provider, default, unknown
- [x] Error propagation tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)